### PR TITLE
Fix version conflicts caused by PR#74

### DIFF
--- a/src/ExpressionPowerTools.Serialization.EFCore.AspNetCore/ExpressionPowerTools.Serialization.EFCore.AspNetCore.csproj
+++ b/src/ExpressionPowerTools.Serialization.EFCore.AspNetCore/ExpressionPowerTools.Serialization.EFCore.AspNetCore.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.8" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ExpressionPowerTools.Serialization.EFCore.Http/ExpressionPowerTools.Serialization.EFCore.Http.csproj
+++ b/src/ExpressionPowerTools.Serialization.EFCore.Http/ExpressionPowerTools.Serialization.EFCore.Http.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Functionality for serializing queries and retrieving results using HttpClient.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>../../docs/api/ExpressionPowerTools.Serialization.EFCore.Http.xml</DocumentationFile>
     <PackageTags>$(PackageTags);Serialization;EFCore</PackageTags>
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.8" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/tools/ExpressionPowerTools.Utilities.DocumentGenerator/ExpressionPowerTools.Utilities.DocumentGenerator.csproj
+++ b/tools/ExpressionPowerTools.Utilities.DocumentGenerator/ExpressionPowerTools.Utilities.DocumentGenerator.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.8" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.EntityFrameworkCore from 3.1.8 to 5.0.8. [(PR#74)](https://github.com/JeremyLikness/ExpressionPowerTools/pull/74).
Hope this fix can help you.

Best regards,
sucrose